### PR TITLE
Fix error messages on non-English Windows

### DIFF
--- a/source/bindbc/loader/sharedlib.d
+++ b/source/bindbc/loader/sharedlib.d
@@ -237,25 +237,42 @@ version(Windows)
         return GetProcAddress(lib, symbolName);
     }
 
+    void wstringToString(char** dst, const(wchar)* src)
+    {
+        auto srcLen = lstrlenW(src);
+        auto dstBuffLen = wchar.sizeof*srcLen + 1;
+        *dst = cast(char*)malloc(dstBuffLen);
+        WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            src,
+            srcLen,
+            *dst,
+            cast(int)dstBuffLen,
+            null,
+            null
+        );
+    }
+
     void sysError(ErrorInfo* pinfo)
     {
-        char* msgBuf;
+        wchar* msgBuf;
         enum uint langID = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
 
-        FormatMessageA(
+        FormatMessageW(
             FORMAT_MESSAGE_ALLOCATE_BUFFER |
             FORMAT_MESSAGE_FROM_SYSTEM |
             FORMAT_MESSAGE_IGNORE_INSERTS,
             null,
             GetLastError(),
             langID,
-            cast(char*)&msgBuf,
+            cast(wchar*)&msgBuf,
             0,
             null
         );
 
         if(msgBuf) {
-            copyString(&pinfo._message, msgBuf);
+            wstringToString(&pinfo._message, msgBuf);
             LocalFree(msgBuf);
         }
         else


### PR DESCRIPTION
With this change bindbc-loader will provide proper UTF-8 error messages on Windows.