### PR TITLE
Fixed: Reduced 300 ms in compilation time on windows

### DIFF
--- a/source/bindbc/loader/sharedlib.d
+++ b/source/bindbc/loader/sharedlib.d
@@ -229,7 +229,10 @@ void addErr(const(char)* errstr, const(char)* message){
 }
 
 version(Windows){
-	import core.sys.windows.windows;
+	import core.sys.windows.winbase;
+	import core.sys.windows.winnt;
+	private alias BOOL = int;
+	private alias HMODULE = void*;
 	extern(Windows) @nogc nothrow alias pSetDLLDirectory = BOOL function(const(char)*);
 	pSetDLLDirectory setDLLDirectory;
 	


### PR DESCRIPTION
Before:
![before](https://github.com/BindBC/bindbc-loader/assets/10136262/f9538ef9-5564-4be3-b148-7da28829a3a0)

After:
![after](https://github.com/BindBC/bindbc-loader/assets/10136262/0d79709e-9c1a-4612-a541-028e2aa0fe5e)

Since this is a recurring dependence, it will benefit the entire ecosystem :)

